### PR TITLE
Add satellite base layer option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "jsonlint-mod": "^1.7.6",
         "leaflet": "^1.7.1",
         "leaflet-coverage": "^0.8.0",
-        "leaflet-loading": "^0.1.24"
+        "leaflet-loading": "^0.1.24",
+        "leaflet-plugins": "^3.4.0"
       },
       "devDependencies": {
         "copy-webpack-plugin": "^10.1.0",
@@ -3176,6 +3177,11 @@
       "version": "0.1.24",
       "resolved": "https://registry.npmjs.org/leaflet-loading/-/leaflet-loading-0.1.24.tgz",
       "integrity": "sha1-6v38GIcY6xPTz3uSJsTAaxbpKRk="
+    },
+    "node_modules/leaflet-plugins": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/leaflet-plugins/-/leaflet-plugins-3.4.0.tgz",
+      "integrity": "sha512-CjsQKaW545tNY4JVm4v3WhbFcUa2QzWQQzEysQ0eY/ThYYMqIL5DnQNgcHCvAFZtEwlj7MlTtI7BFuKiNuqyJA=="
     },
     "node_modules/levn": {
       "version": "0.3.0",
@@ -8622,6 +8628,11 @@
       "version": "0.1.24",
       "resolved": "https://registry.npmjs.org/leaflet-loading/-/leaflet-loading-0.1.24.tgz",
       "integrity": "sha1-6v38GIcY6xPTz3uSJsTAaxbpKRk="
+    },
+    "leaflet-plugins": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/leaflet-plugins/-/leaflet-plugins-3.4.0.tgz",
+      "integrity": "sha512-CjsQKaW545tNY4JVm4v3WhbFcUa2QzWQQzEysQ0eY/ThYYMqIL5DnQNgcHCvAFZtEwlj7MlTtI7BFuKiNuqyJA=="
     },
     "levn": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "jsonlint-mod": "^1.7.6",
     "leaflet": "^1.7.1",
     "leaflet-coverage": "^0.8.0",
-    "leaflet-loading": "^0.1.24"
+    "leaflet-loading": "^0.1.24",
+    "leaflet-plugins": "^3.4.0"
   },
   "devDependencies": {
     "copy-webpack-plugin": "^10.1.0",

--- a/src/config.js
+++ b/src/config.js
@@ -1,10 +1,7 @@
+export const BingMapsApiKey = 'AjAVy4nLckUAUX7gML0AAT4ym6XLYoGCn_6H9mi5UY9fuZyWx3N3wIDcIx5VESHP'
+
 export const initialMapZoom = 2
 export const initialMapCenter = [10, 0]
-
-export const baseMap = {
-    url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-    attribution: 'Map data &copy; <a href="http://www.osm.org">OpenStreetMap</a>'
-}
 
 // TODO replace with final URL
 // export const schemaUrl = 'https://covjson.org/schema.json'

--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,7 @@ import 'leaflet-loading'
 import 'leaflet-loading/src/Control.Loading.css'
 
 import './leaflet-singleclick.js'
+import 'leaflet-plugins/layer/tile/Bing.js'
 
 import * as CovJSON from 'covjson-reader'
 import * as C from 'leaflet-coverage'
@@ -35,12 +36,21 @@ let map = L.map(mapEl, {
 
 L.control.scale().addTo(map)
 
-const baseLayer = L.tileLayer(config.baseMap.url, {
-    attribution: config.baseMap.attribution
-})
-baseLayer.addTo(map)
+const baseLayers = {
+  'Map': L.tileLayer(
+    'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', 
+    {
+      attribution: 'Map data &copy; <a href="http://www.osm.org">OpenStreetMap</a>',
+    }).addTo(map),
+  'Satellite': L.bingLayer(
+    config.BingMapsApiKey,
+    {
+      imagerySet: 'Aerial',
+    }
+  )
+}
 
-let layerControl = L.control.layers([], [], {collapsed: false}).addTo(map)
+let layerControl = L.control.layers(baseLayers, {}, {collapsed: false}).addTo(map)
 
 // We use ParameterSync here so that multiple coverage layers that display the same
 // parameter get synchronized in terms of their palette and extent.


### PR DESCRIPTION
This adds Bing Maps' Aerial tile layer following https://docs.microsoft.com/en-us/bingmaps/rest-services/directly-accessing-the-bing-maps-tiles. I created a free Bing Maps account for this which comes with an API key that is used for fetching the metadata document at website load (through a leaflet plugin). The actual tiles do not make use of the API key and are therefore not counted towards any free quota.
Side note: Google doesn't permit to access its imagery outside of their own SDKs.

![image](https://user-images.githubusercontent.com/530988/152697396-5c39d14b-9bbb-483a-b1dd-6406a88366c2.png)
