### PR TITLE
Prettify single-line pastes if full editor content is replaced

### DIFF
--- a/src/Editor.js
+++ b/src/Editor.js
@@ -119,6 +119,18 @@ export default class Editor extends L.Class {
         this.fire('change', {text})
       }
     })
+
+    cm.on('beforeChange', (cm, change) => {
+      if (change.origin !== 'paste')
+        return
+      if (change.from.line !== 0 || change.from.ch !== 0) 
+        return
+      if (change.to.line !== cm.lastLine()) 
+        return
+      let text = change.text.join('\n')
+      text = maybePrettifySingleLineJSON(text)
+      change.text = text.split('\n')
+    })
   }
 
   _getAnnotations(text) {


### PR DESCRIPTION
Automatic prettifying for single-line JSON is already done when loading documents via URL. This extends it to copy-paste actions that replace the full editor content. 